### PR TITLE
fix: 배지 최고 레벨 조회 쿼리 중복 버그 수정

### DIFF
--- a/src/main/java/com/groom/sumbisori/domain/badge/repository/UserBadgeQueryRepository.java
+++ b/src/main/java/com/groom/sumbisori/domain/badge/repository/UserBadgeQueryRepository.java
@@ -25,12 +25,11 @@ public class UserBadgeQueryRepository {
                         Projections.constructor(
                                 BadgeIdAndLevel.class,
                                 userBadge.badgeLevel.badge.id,
-                                userBadge.badgeLevel.level
+                                userBadge.badgeLevel.level.max()
                         ))
                 .from(userBadge)
                 .where(userBadge.userId.eq(userId))
-                .groupBy(userBadge.badgeLevel.badge.id, userBadge.badgeLevel.level)
-                .having(userBadge.badgeLevel.level.max().eq(userBadge.badgeLevel.level))
+                .groupBy(userBadge.badgeLevel.badge.id)
                 .fetch();
         return results.stream()
                 .collect(Collectors.toMap(


### PR DESCRIPTION
## Overview

- 배지 조회시 중복 버그 수정

## Issue Tags

- Closed: #97 
